### PR TITLE
TASK: Adding ability to read NFC tags

### DIFF
--- a/app/src/main/java/com/ridge/digitalreceiptreader/LoginActivity.java
+++ b/app/src/main/java/com/ridge/digitalreceiptreader/LoginActivity.java
@@ -2,22 +2,15 @@ package com.ridge.digitalreceiptreader;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-import android.app.PendingIntent;
-import android.content.Context;
 import android.content.Intent;
 import android.nfc.NdefMessage;
-import android.nfc.NfcAdapter;
-import android.nfc.NfcManager;
 import android.os.Bundle;
-import android.os.Parcelable;
 import android.util.Log;
 import android.widget.Button;
 import android.widget.TextView;
 
 import com.ridge.digitalreceiptreader.service.LoginService;
 import com.ridge.digitalreceiptreader.service.NfcService;
-
-import java.io.UnsupportedEncodingException;
 
 /**
  * Login Activity class for handling functionality with the login screen.
@@ -33,8 +26,6 @@ public class LoginActivity extends AppCompatActivity {
     private Button loginButton;
 
     private TextView forgotPassword;
-
-    private NfcAdapter adapter = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/ridge/digitalreceiptreader/service/LoginService.java
+++ b/app/src/main/java/com/ridge/digitalreceiptreader/service/LoginService.java
@@ -1,9 +1,7 @@
 package com.ridge.digitalreceiptreader.service;
 
 import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -81,8 +79,8 @@ public class LoginService {
      * Login click event for when the user clicks the login button.
      */
     public void onLogin() {
-        String email = emailInput.getText().toString().trim() == "" ? " " : emailInput.getText().toString().trim();
-        String password = passwordInput.getText().toString().trim() == "" ? " " : passwordInput.getText().toString().trim();
+        String email = emailInput.getText().toString().trim().equals("") ? " " : emailInput.getText().toString().trim();
+        String password = passwordInput.getText().toString().trim().equals("") ? " " : passwordInput.getText().toString().trim();
 
         showLoading();
         authClient.authenticate(email, password).subscribe(res -> currentActivity.runOnUiThread(() -> validateToken(res)));

--- a/app/src/main/java/com/ridge/digitalreceiptreader/service/NfcService.java
+++ b/app/src/main/java/com/ridge/digitalreceiptreader/service/NfcService.java
@@ -23,7 +23,7 @@ public class NfcService {
 
     private NfcAdapter adapter = null;
 
-    private ToastService toastService;
+    private final ToastService toastService;
 
     /**
      * Sets default values for the class.
@@ -49,7 +49,7 @@ public class NfcService {
     }
 
     /**
-     * When the application starts and the processes are in the foreground. This will endable the dispatch 
+     * When the application starts and the processes are in the foreground. This will enable the dispatch
      * of the NFC adapter so it can pick up the information from the tag.
      */
     public void enableNfcForegroundDispatch() {
@@ -67,7 +67,7 @@ public class NfcService {
     }
 
     /**
-     * When the application is closed or clossing or we don't want to read NFC tags at this time then
+     * When the application is closed or closing or we don't want to read NFC tags at this time then
      * we need to disable the adapter.
      */
     public void disableNfcForegroundDispatch() {
@@ -124,7 +124,7 @@ public class NfcService {
         String text = "";
         byte[] payload = msg.getRecords()[0].getPayload();
         String textEncoding = ((payload[0] & 128) == 0) ? "UTF-8" : "UTF-16";
-        int languageCodeLength = payload[0] & 0063;
+        int languageCodeLength = payload[0] & 0x0063;
 
         try {
             text = new String(payload, languageCodeLength + 1, payload.length - languageCodeLength - 1, textEncoding);

--- a/app/src/main/java/com/ridge/digitalreceiptreader/service/NfcService.java
+++ b/app/src/main/java/com/ridge/digitalreceiptreader/service/NfcService.java
@@ -53,6 +53,10 @@ public class NfcService {
      * of the NFC adapter so it can pick up the information from the tag.
      */
     public void enableNfcForegroundDispatch() {
+        if(adapter == null) {
+            return;
+        }
+
         try {
             Intent intent = new Intent(currentActivity, currentActivity.getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
             PendingIntent nfcPendingIntent = PendingIntent.getActivity(currentActivity, 0, intent, 0);
@@ -67,6 +71,10 @@ public class NfcService {
      * we need to disable the adapter.
      */
     public void disableNfcForegroundDispatch() {
+        if(adapter == null) {
+            return;
+        }
+
         try {
             adapter.disableForegroundDispatch(currentActivity);
         } catch (IllegalStateException ex) {
@@ -82,6 +90,10 @@ public class NfcService {
      * @return {@link NdefMessage} of the data read from the tag.
      */
     public NdefMessage[] readTag(Intent intent) {
+        if(adapter == null) {
+            return null;
+        }
+
         if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intent.getAction())) {
             Parcelable[] rawMessages = intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES);
             if (rawMessages != null) {
@@ -103,6 +115,10 @@ public class NfcService {
      * @return {@link String} of the data in the message.
      */
     public String buildTagView(NdefMessage msg) {
+        if(adapter == null) {
+            return null;
+        }
+
         if (msg == null) return "";
 
         String text = "";

--- a/app/src/main/java/com/ridge/digitalreceiptreader/service/NfcService.java
+++ b/app/src/main/java/com/ridge/digitalreceiptreader/service/NfcService.java
@@ -1,0 +1,121 @@
+package com.ridge.digitalreceiptreader.service;
+
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.nfc.NdefMessage;
+import android.nfc.NfcAdapter;
+import android.nfc.NfcManager;
+import android.os.Parcelable;
+import android.util.Log;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Class for dealing with all initializations and readings from NFC.
+ *
+ * @author Sam Butler
+ * @since September 10, 2021
+ */
+public class NfcService {
+    private final Activity currentActivity;
+
+    private NfcAdapter adapter = null;
+
+    private ToastService toastService;
+
+    /**
+     * Sets default values for the class.
+     *
+     * @param a current activity.
+     */
+    public NfcService(Activity a) {
+        currentActivity = a;
+        toastService = new ToastService(currentActivity);
+    }
+
+    /**
+     * This will initialize the nfc adapter in order to intercept any NFC tags being tapped to the phone.
+     * If the adapter is null then the phone does not support nfc and a warning will display at the
+     * top of the phone.
+     */
+    public void initAdapter() {
+        NfcManager nfcManager = (NfcManager)currentActivity.getSystemService(Context.NFC_SERVICE);
+        adapter = nfcManager.getDefaultAdapter();
+        if(adapter == null) {
+            toastService.showWarning("This device does not support NFC");
+        }
+    }
+
+    /**
+     * When the application starts and the processes are in the foreground. This will endable the dispatch 
+     * of the NFC adapter so it can pick up the information from the tag.
+     */
+    public void enableNfcForegroundDispatch() {
+        try {
+            Intent intent = new Intent(currentActivity, currentActivity.getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            PendingIntent nfcPendingIntent = PendingIntent.getActivity(currentActivity, 0, intent, 0);
+            adapter.enableForegroundDispatch(currentActivity, nfcPendingIntent, null, null);
+        } catch (IllegalStateException ex) {
+            Log.e("NFC", "Error enabling NFC foreground dispatch");
+        }
+    }
+
+    /**
+     * When the application is closed or clossing or we don't want to read NFC tags at this time then
+     * we need to disable the adapter.
+     */
+    public void disableNfcForegroundDispatch() {
+        try {
+            adapter.disableForegroundDispatch(currentActivity);
+        } catch (IllegalStateException ex) {
+            Log.e("NFC", "Error disabling NFC foreground dispatch");
+        }
+    }
+
+    /**
+     * This will read the data from the tag and store it in an {@link NdefMessage} array
+     * object. If nothing can be pulled from the tag, then the method will return null.
+     *
+     * @param intent The intent the tag was triggered on.
+     * @return {@link NdefMessage} of the data read from the tag.
+     */
+    public NdefMessage[] readTag(Intent intent) {
+        if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intent.getAction())) {
+            Parcelable[] rawMessages = intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES);
+            if (rawMessages != null) {
+                NdefMessage[] messages = new NdefMessage[rawMessages.length];
+                for (int i = 0; i < rawMessages.length; i++) {
+                    messages[i] = (NdefMessage) rawMessages[i];
+                }
+                return messages;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Will build the tag view into a {@link String} object from the given {@link NdefMessage}
+     * object.
+     *
+     * @param msg The message to get data from.
+     * @return {@link String} of the data in the message.
+     */
+    public String buildTagView(NdefMessage msg) {
+        if (msg == null) return "";
+
+        String text = "";
+        byte[] payload = msg.getRecords()[0].getPayload();
+        String textEncoding = ((payload[0] & 128) == 0) ? "UTF-8" : "UTF-16";
+        int languageCodeLength = payload[0] & 0063;
+
+        try {
+            text = new String(payload, languageCodeLength + 1, payload.length - languageCodeLength - 1, textEncoding);
+        } catch (UnsupportedEncodingException e) {
+            Log.e("UnsupportedEncoding", e.toString());
+        }
+
+        return text;
+    }
+}

--- a/app/src/main/java/com/ridge/digitalreceiptreader/service/ToastService.java
+++ b/app/src/main/java/com/ridge/digitalreceiptreader/service/ToastService.java
@@ -3,11 +3,9 @@ package com.ridge.digitalreceiptreader.service;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
-import android.text.Html;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.view.Window;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -21,7 +19,7 @@ import com.ridge.digitalreceiptreader.R;
  * @since July 28, 2021
  */
 public class ToastService {
-    private Context currentContext;
+    private final Context currentContext;
 
     /**
      * Sets the current Context to the passed in activity context
@@ -76,7 +74,7 @@ public class ToastService {
     }
 
     /**
-     * Get the default view layout for the toast message witht he given message and
+     * Get the default view layout for the toast message with he given message and
      * background color.
      *
      * @param backgroundColor Color to set the background of the toast message
@@ -101,7 +99,7 @@ public class ToastService {
      * @param layout  View for color to be applied too.
      */
     private void setBackgroundColor(String bgColor, View layout) {
-        LinearLayout square = (LinearLayout) layout.findViewById(R.id.toast_background);
+        LinearLayout square = layout.findViewById(R.id.toast_background);
         square.getBackground().setColorFilter(Color.parseColor(bgColor), PorterDuff.Mode.SRC_ATOP);
     }
 
@@ -112,7 +110,7 @@ public class ToastService {
      * @param layout  Layout to display message on.
      */
     private void setTextViewMessage(String message, View layout) {
-        TextView textView = (TextView) layout.findViewById(R.id.toast_message);
+        TextView textView = layout.findViewById(R.id.toast_message);
         textView.setText(message);
         textView.setTextColor(Color.WHITE);
     }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -116,11 +116,15 @@
         android:id="@+id/textView2"
         android:layout_width="268dp"
         android:layout_height="281dp"
-        android:layout_marginStart="228dp"
-        android:layout_marginLeft="228dp"
-        android:layout_marginBottom="104dp"
+        android:layout_marginStart="244dp"
+        android:layout_marginLeft="244dp"
+        android:layout_marginBottom="84dp"
         android:background="@drawable/login_background"
         android:rotation="-40"
         app:layout_constraintBottom_toTopOf="@+id/email_textbox__login"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.148"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.813" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -126,5 +126,5 @@
         app:layout_constraintHorizontal_bias="0.148"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.813" />
+        app:layout_constraintVertical_bias="1.0" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### What Changed:
- Added NFC service to handle the initialization and reading of the NFC tag.
- Having login component be the test Activity to confirm that reader works.
- The future updates will have NFC have its own activity in order to read data from a tag.

### Testing:
- Can pull down the changes and run the app on a physical phone and confirm that when you tap it a log is displayed in Android studio saying what data is on the tag.